### PR TITLE
Fix project variable; only include PR merges

### DIFF
--- a/deploy_pr
+++ b/deploy_pr
@@ -4,7 +4,7 @@
 project=$(git remote show upstream | grep Fetch | sed 's/.*github.com\/\(artsy\/.*\)\.git/\1/')
 
 # show included PRs
-prs=$(git log upstream/release...upstream/master --merges --oneline --grep 'from artsy/master' --invert-grep | cut -d ' ' -f 5 | cut -d '#' -f 2)
+prs=$(git log upstream/release...upstream/master --merges --oneline --grep 'from artsy/master' --invert-grep | grep 'Merge pull request' | cut -d ' ' -f 5 | cut -d '#' -f 2)
 
 body="Included PRs:\n\n"
 for pr in $prs; do

--- a/deploy_pr
+++ b/deploy_pr
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # get project name
-project=$(git remote show upstream | grep Fetch | cut -d ':' -f 3 | cut -d '.' -f 1)
+project=$(git remote show upstream | grep Fetch | sed 's/.*github.com\/\(artsy\/.*\)\.git/\1/')
 
 # show included PRs
 prs=$(git log upstream/release...upstream/master --merges --oneline --grep 'from artsy/master' --invert-grep | cut -d ' ' -f 5 | cut -d '#' -f 2)


### PR DESCRIPTION
This script is super useful! 🥇 

While creating a deploy PR at https://github.com/artsy/volt/pull/2562, I noticed 2 things we can improve from the screenshot:
<img width="1024" alt="screen shot 2017-06-06 at 12 45 56 pm" src="https://user-images.githubusercontent.com/796573/26842381-a15e103e-4aba-11e7-9624-759a17ed29b4.png">

1. The `project` variable was slightly off.
1. The PR list included non-pull request merges, for example, if I merged from the latest master in my PR a couple of times, they will be included as well. Let's explicitly find "Merge pull request" in the message for now.

The result looked like:
![screen shot 2017-06-06 at 1 23 00 pm](https://user-images.githubusercontent.com/796573/26842587-53c8b788-4abb-11e7-91da-2b7276f7635c.png)

