### PR TITLE
Add deploy label

### DIFF
--- a/deploy_pr
+++ b/deploy_pr
@@ -17,4 +17,4 @@ read -p 'title: ' title
 
 # create deploy PR
 message="Deploy: $title\n\n$body"
-echo $message | hub pull-request -b $project:release -h $project:master -F -
+echo $message | hub pull-request -b $project:release -h $project:master -l deploy -F -


### PR DESCRIPTION
# Change
We normally add _deploy_ label to deploy pull requests. Looks like hub also [supports](https://github.com/github/hub/blob/e3ad4ef7e59a95f469c6b1de1b4c3b96d6cb59f4/features/pull_request.feature#L786) it by passing `-l`.

One thing Im not sure is what happens when label doesn't exist, would it create one? We can try that.
