### PR TITLE
Fetch latest upstream before comparing logs

### DIFF
--- a/deploy_pr
+++ b/deploy_pr
@@ -3,6 +3,9 @@
 # get project name
 project=$(git remote show upstream | grep Fetch | sed 's/.*github.com\/\(artsy\/.*\)\.git/\1/')
 
+# fetch latest upstream to local
+git fetch upstream
+
 # show included PRs
 prs=$(git log upstream/release...upstream/master --merges --oneline --grep 'from artsy/master' --invert-grep | grep 'Merge pull request' | cut -d ' ' -f 5 | cut -d '#' -f 2)
 


### PR DESCRIPTION
`git log` would only display logs that are already fetched to our local repo, so I had to fetch upstream before running the script. Maybe it makes sense to update local upstream repo before comparing the master and release branch?

![screen shot 2017-06-13 at 2 05 02 pm](https://user-images.githubusercontent.com/796573/27097310-d0cbba2e-5041-11e7-93b5-3d7c0a842294.png)
