### PR TITLE
Simplify getting project name

### DIFF
--- a/deploy_pr
+++ b/deploy_pr
@@ -13,7 +13,7 @@ if ! command -v hub > /dev/null; then
 fi
 
 # get project name
-project=$(git remote show upstream | grep Fetch | sed 's/.*github.com\/\(artsy\/.*\)\.git/\1/')
+project=$(basename "$PWD")
 
 # fetch latest upstream to local
 git fetch upstream


### PR DESCRIPTION
I had a problem getting the current script to work and asked about it here:

https://github.com/jonallured/deploy_pr/commit/775ce4ea9e9b12a6b68c5f41afbf31b1b0db9a4e#commitcomment-22652905

But then after thinking about this a little more, I realized that I was being way too clever about computing the project name. Using `basename` on the current directory name is waaay easier to understand and just about as foolproof.

It does mean, however, that if you decided to clone one of our projects and change the name of the folder, the script wouldn't work. Seems edgy to me and not worth worrying about.

/cc @starsirius 