### PR TITLE
Add dry run and default to merging deployment PRs

### DIFF
--- a/deploy_pr
+++ b/deploy_pr
@@ -34,9 +34,13 @@ for pr in $prs; do
   echo https://github.com/$project/issues/$pr
 done
 
-# ask for title
-read -p 'title: ' title
+if [[ $* == *--dry-run* ]]; then
+  echo 'Dry run, no PR created.'
+else
+  # ask for title
+  read -p 'title: ' title
 
-# create deploy PR
-message="Deploy: $title\n\n$body"
-echo $message | hub pull-request -b $project:release -h $project:master -F -
+  # create deploy PR
+  message="Deploy: $title\n\n$body"
+  echo $message | hub pull-request -b $project:release -h $project:master -F -
+fi

--- a/deploy_pr
+++ b/deploy_pr
@@ -55,5 +55,19 @@ else
 
   # create deploy PR
   message="Deploy: $title\n\n$body"
-  echo $message | hub pull-request -b $project:release -h $project:master -F -
+  pr_url=$(echo $message | hub pull-request -b $project:release -h $project:master -F -)
+
+
+  if [[ $* == *--no-merge ]]; then
+    echo $pr_url
+  else
+    # merge deploy PR
+    git checkout upstream/release --quiet
+    hub merge $pr_url --quiet > /dev/null 2>&1
+    git push upstream HEAD:release --quiet
+    git checkout master --quiet
+    echo 'Deployment PR merged.'
+  fi
+
+  echo $pr_url
 fi

--- a/deploy_pr
+++ b/deploy_pr
@@ -2,20 +2,20 @@
 
 # ensure we're in a git repo
 if ! [ -d .git ]; then
-  echo 'Please run from a git repo'
+  echo 'Please run from a git repo.'
   exit 1
 fi
 
 # ensure hub is installed
 if ! command -v hub > /dev/null; then
-  echo 'Please brew install hub'
+  echo 'Please brew install hub.'
   exit 2
 fi
 
 # ensure there's an upstream remote
 git remote | grep upstream --quiet
 if [ $? -ne 0 ] ; then
-  echo 'Please set an upstream remote'
+  echo 'Please set an upstream remote.'
   exit 3
 fi
 

--- a/deploy_pr
+++ b/deploy_pr
@@ -19,6 +19,19 @@ if [ $? -ne 0 ] ; then
   exit 3
 fi
 
+# ensure we're on master
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "master" ]; then
+  echo 'Please switch to master branch.'
+  return 4
+fi
+
+# ensure working copy is clean
+if [[ -n $(git status -s) ]]; then
+  echo 'Please commit any unsaved changes.'
+  exit 5
+fi
+
 # get project name
 project=artsy/$(basename "$PWD")
 

--- a/deploy_pr
+++ b/deploy_pr
@@ -12,6 +12,13 @@ if ! command -v hub > /dev/null; then
   exit 2
 fi
 
+# ensure there's an upstream remote
+git remote | grep upstream --quiet
+if [ $? -ne 0 ] ; then
+  echo 'Please set an upstream remote'
+  exit 3
+fi
+
 # get project name
 project=artsy/$(basename "$PWD")
 


### PR DESCRIPTION
The PR does a lot of little things to (hopefully!) make the experience better. One thing that bothered me about this script was it's lack of checks, so I've added a few more. Basically I wanted to make sure that the script isn't going to goof anything up for you.

With that out of the way, I've added two new features:

* you can pass the `--dry-run` flag to see which merged PRs will be included in the deployment
* by default the deployment PR will be merged after it's created, you can skip the merge with `--no-merge`

But the thing that I'm most excited about on this one is that I figured out a way to smoke test this script! I created a test repo here:

https://github.com/artsy/deploy_pr_test

The only thing there is really just a script that [creates and merges PRs](https://github.com/artsy/deploy_pr_test/blob/master/add_timestamp). I can then use as a test when working on `deploy_pr` like this:

```
$ ./add_timestamp
...PR is created and merged...
$ ../deploy_pr/deploy_pr
```

So I can make a change to the script, flip over to the test app and run it from there to see if it does what I expect. ✨ 

/cc @starsirius @anandaroop @oxaudo @starsirius @ashkan18